### PR TITLE
Feature/13 return errors

### DIFF
--- a/src/main/java/org/sobotics/redunda/PingService.java
+++ b/src/main/java/org/sobotics/redunda/PingService.java
@@ -232,8 +232,8 @@ public class PingService {
 			}
 		} catch (Throwable e) {
 			//no apikey or server might be offline; don't change status!
-			e.printStackTrace();
 			this.forwardError(e);
+			throw e;
 		}
 	}
 	

--- a/src/main/java/org/sobotics/redunda/PingService.java
+++ b/src/main/java/org/sobotics/redunda/PingService.java
@@ -155,9 +155,8 @@ public class PingService {
 			this.execute();
 			return PingService.standby.get();
 		} catch (Throwable e) {
-			e.printStackTrace();
 			this.forwardError(e);
-			return true;
+			throw e;
 		}
 	}
 	
@@ -238,7 +237,11 @@ public class PingService {
 		}
 	}
 	
-	
+	/**
+	 * Sends a thrown error to the delegate, if the delegate is not null.
+	 * 
+	 * @param e The exception
+	 * */
 	private void forwardError(Throwable e) {
 		if (this.delegate != null)
 			this.delegate.error(e);

--- a/src/main/java/org/sobotics/redunda/PingService.java
+++ b/src/main/java/org/sobotics/redunda/PingService.java
@@ -154,6 +154,7 @@ public class PingService {
 			return PingService.standby.get();
 		} catch (Throwable e) {
 			e.printStackTrace();
+			this.forwardError(e);
 			return true;
 		}
 	}
@@ -166,6 +167,7 @@ public class PingService {
 			this.execute();
 		} catch (Throwable e) {
 			e.printStackTrace();
+			this.forwardError(e);
 		}
 	}
 	
@@ -230,6 +232,13 @@ public class PingService {
 		} catch (Throwable e) {
 			//no apikey or server might be offline; don't change status!
 			e.printStackTrace();
+			this.forwardError(e);
 		}
+	}
+	
+	
+	private void forwardError(Throwable e) {
+		if (this.delegate != null)
+			this.delegate.error(e);
 	}
 }

--- a/src/main/java/org/sobotics/redunda/PingService.java
+++ b/src/main/java/org/sobotics/redunda/PingService.java
@@ -147,8 +147,10 @@ public class PingService {
 	 * The value is affected by the debug-mode.
 	 * 
 	 * @return The standby-status
+	 * 
+	 * @throws Throwable, if an error occurs. Additionally, delegate.error() will be called
 	 * */
-	public boolean checkStandbyStatus() {
+	public boolean checkStandbyStatus() throws Throwable {
 		try {
 			this.execute();
 			return PingService.standby.get();

--- a/src/main/java/org/sobotics/redunda/PingServiceDelegate.java
+++ b/src/main/java/org/sobotics/redunda/PingServiceDelegate.java
@@ -7,4 +7,6 @@ public interface PingServiceDelegate {
 	 * @param newStatus The new status
 	 * */
 	void standbyStatusChanged(boolean newStatus);
+	
+	void error(Throwable e);
 }


### PR DESCRIPTION
`PingService.checkStandbyStatus()` (which should only be executed once during launch) now throws any errors that can occur.

`PingServiceDelegate` can now receive errors by implementing the `error()`-method.